### PR TITLE
Closes #122 - MaterialComponents

### DIFF
--- a/PhotoPoints/app/build.gradle
+++ b/PhotoPoints/app/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.navigation:navigation-fragment:2.2.1'
     implementation 'androidx.navigation:navigation-ui:2.2.1'

--- a/PhotoPoints/app/src/main/res/layout/activity_splash.xml
+++ b/PhotoPoints/app/src/main/res/layout/activity_splash.xml
@@ -21,7 +21,7 @@
         android:layout_gravity="center_horizontal"
         app:layout_constraintBottom_toTopOf="@id/image_photoPointsLogo"/>
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:layout_marginBottom="25dp"
         android:text="@string/synching_data"
         android:layout_gravity="center_horizontal"

--- a/PhotoPoints/app/src/main/res/layout/fragment_details.xml
+++ b/PhotoPoints/app/src/main/res/layout/fragment_details.xml
@@ -51,7 +51,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/image_photoPoint" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_plantName"
         style="@android:style/Widget.DeviceDefault.TextView"
         android:layout_width="wrap_content"
@@ -64,7 +64,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/divider" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_plantDescription"
         style="@android:style/Widget.DeviceDefault.TextView"
         android:layout_width="wrap_content"
@@ -74,7 +74,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/text_scientificName" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_scientificName"
         style="@android:style/Widget.DeviceDefault.TextView"
         android:layout_width="wrap_content"

--- a/PhotoPoints/app/src/main/res/layout/fragment_details.xml
+++ b/PhotoPoints/app/src/main/res/layout/fragment_details.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 
+<!--TODO: BREAK OUT COLOR/STYLE -->
+
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -36,7 +38,9 @@
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:srcCompat="@tools:sample/backgrounds/scenic" />
+        tools:srcCompat="@tools:sample/backgrounds/scenic"
+        android:contentDescription="TODO" />
+
 
     <View
         android:id="@+id/divider"
@@ -60,7 +64,7 @@
         android:layout_marginTop="4dp"
         android:ems="10"
         android:text="name_placeholder"
-        android:textSize="20dp"
+        android:textSize="20sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/divider" />
 
@@ -82,7 +86,7 @@
         android:layout_marginStart="20dp"
         android:ems="10"
         android:text="scientific_placeholder"
-        android:textSize="10dp"
+        android:textSize="12sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/text_plantName" />
 
@@ -93,6 +97,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:clickable="true"
+        android:focusable="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:srcCompat="@mipmap/cloud_upload" />

--- a/PhotoPoints/app/src/main/res/layout/fragment_scan.xml
+++ b/PhotoPoints/app/src/main/res/layout/fragment_scan.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_pleaseScan"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -15,7 +15,7 @@
         android:layout_marginTop="20dp"
         android:textSize="16sp"/>
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_scanResult"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/PhotoPoints/app/src/main/res/layout/fragment_sign_in.xml
+++ b/PhotoPoints/app/src/main/res/layout/fragment_sign_in.xml
@@ -46,7 +46,7 @@
         android:text="@string/login"
         app:rippleColor="@color/colorAccent"/>
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_signup"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"

--- a/PhotoPoints/app/src/main/res/layout/fragment_upload_photo_point_data.xml
+++ b/PhotoPoints/app/src/main/res/layout/fragment_upload_photo_point_data.xml
@@ -22,14 +22,14 @@
                     android:layout_marginBottom="25dp"
                     android:orientation="vertical">
 
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/text_name"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="placeholder_PhotoPointName"
                         android:textSize="22sp" />
 
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/text_surveyData"
                         style="@style/TextViewNormal"
                         android:text="@string/survey_data" />
@@ -42,14 +42,14 @@
                         android:layout_marginTop="10dp"
                         android:orientation="vertical">
 
-                        <TextView
+                        <com.google.android.material.textview.MaterialTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="placeholder_sampleData" />
 
                     </LinearLayout>
 
-                    <TextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/text_focusOn"
                         style="@style/TextViewNormal"
                         android:text="@string/picture_focus" />
@@ -62,7 +62,7 @@
                         android:layout_marginTop="10dp"
                         android:orientation="vertical">
 
-                        <TextView
+                        <com.google.android.material.textview.MaterialTextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="placeholder_sampleData" />

--- a/PhotoPoints/app/src/main/res/layout/viewholder_photopoint.xml
+++ b/PhotoPoints/app/src/main/res/layout/viewholder_photopoint.xml
@@ -28,14 +28,14 @@
                 android:id="@+id/image_photopoint_displayphoto"
                 />
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:layout_height="wrap_content"
                 android:layout_width="match_parent"
                 android:textSize="8pt"
                 android:textAlignment="center"
                 android:id="@+id/text_photopoint_displaytext"/>
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:layout_height="wrap_content"
                 android:layout_width="match_parent"
                 android:textSize="7pt"

--- a/PhotoPoints/app/src/main/res/values/colors.xml
+++ b/PhotoPoints/app/src/main/res/values/colors.xml
@@ -3,7 +3,6 @@
     <color name="colorPrimary">#008577</color>
     <color name="colorPrimaryDark">#00574B</color>
     <color name="colorAccent">#D81B60</color>
-    <color name="fragmentBackground">#ffffff</color>
 
 
     <!-- PATH COLORS -->
@@ -11,5 +10,11 @@
     <color name="ColorPathTrail">#fff2af</color>
     <color name="ColorPathMinorTrail">#fff2af</color>
     <color name="ColorPathCreek">#aadaff</color>
+
+
+    <!-- CUSTOM COLORS -->
+    <color name="photopoints_background">#FFFFFF</color>
+    <color name="fragmentBackground">#ffffff</color>
+
 
 </resources>

--- a/PhotoPoints/app/src/main/res/values/photopoints_background.xml
+++ b/PhotoPoints/app/src/main/res/values/photopoints_background.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="photopoints_background">#FFFFFF</color>
-</resources>

--- a/PhotoPoints/app/src/main/res/values/styles.xml
+++ b/PhotoPoints/app/src/main/res/values/styles.xml
@@ -1,7 +1,8 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <!-- TODO:  UPDATE TO SUPPORT DAYNIGHT -->
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
@@ -13,9 +14,9 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar" />
 
-    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.MaterialComponents.Light" />
 
     <style name="Button" parent="Widget.MaterialComponents.Button">
         <item name="android:layout_width">match_parent</item>
@@ -23,7 +24,7 @@
         <item name="android:layout_marginTop">10dp</item>
         <item name="android:textAlignment">center</item>
         <item name="android:padding">5dp</item>
-        <item name="android:textAppearance">@style/TextAppearance.AppCompat.Large</item>
+        <item name="android:textAppearance">@style/TextAppearance.MaterialComponents.Button</item>
         <item name="android:background">@color/colorPrimary</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:layout_marginStart">15dp</item>
@@ -36,14 +37,14 @@
         <item name="android:layout_marginTop">15dp</item>
     </style>
 
-    <style name="TextInputLayout" parent="Widget.Design.TextInputLayout">
+    <style name="TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="android:layout_marginStart">15dp</item>
         <item name="android:layout_marginEnd">15dp</item>
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
     </style>
 
-    <style name="TextViewNormal" parent="Widget.AppCompat.TextView">
+    <style name="TextViewNormal" parent="Widget.MaterialComponents.TextView">
         <item name="android:layout_marginTop">20dp</item>
         <item name="android:textSize">18sp</item>
         <item name="android:layout_width">wrap_content</item>
@@ -51,3 +52,4 @@
     </style>
 
 </resources>
+


### PR DESCRIPTION
Themes migrated from `Theme.AppCompat` to `Theme.MaterialComponents` per Google recommendation, required for MaterialComponents version upgrade from 1.0.0 to 1.1.0